### PR TITLE
Added a missing comma in the Sample Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ A module that displays the next records from the Rennes Star metro.
   header: "Metro",
   position: "top_right",
   config: {
-    updateInterval: 30 // 30 seconds
+    updateInterval: 30, // 30 seconds
     stationName: "Saint-Anne",
     direction: 1,
     displayedRecords: 3


### PR DESCRIPTION
If you copy and paste the sample configuration to be able to test quickly, it doesn't work because a comma is missing after "updateInterval: 30" (It should be : "updateInterval: 30,")